### PR TITLE
🐛 Fix: Visual Bug Fixes for FA Homepage

### DIFF
--- a/components/ItemContainer/ItemContainer.js
+++ b/components/ItemContainer/ItemContainer.js
@@ -28,7 +28,7 @@ const ItemContainer = ({ index, item }) => {
       elevation={3}
       sx={{
         minWidth: '20vw',
-        width: { xs: '90%', sm: '70%', md: '50%', lg: '40%', xl: '30%' },
+        width: { xs: '90%', sm: '70%', md: '55%', lg: '45%', xl: '35%' },
         padding: 2,
         display: 'flex',
         flexDirection: 'column',

--- a/inventory/src/js/itemIndex.js
+++ b/inventory/src/js/itemIndex.js
@@ -29,12 +29,9 @@ const ItemIndex = () => {
       <Stack
         direction='column'
         alignItems='center'
+        justifyContent='center'
         spacing={5}
         marginTop={'100px'}
-        paddingTop={5}
-        sx={{
-          height: '100vh',
-        }}
       >
         {itemsToDisplay.map((item, index) => {
           return <ItemContainer key={index} index={index} item={item} />;

--- a/inventory/src/js/itemIndex.js
+++ b/inventory/src/js/itemIndex.js
@@ -28,10 +28,10 @@ const ItemIndex = () => {
       <NavBar user={user} />
       <Stack
         direction='column'
-        alignItems='center'
         justifyContent='center'
+        alignItems='center'
         spacing={5}
-        marginTop={'100px'}
+        sx={{ marginTop: 10 }}
       >
         {itemsToDisplay.map((item, index) => {
           return <ItemContainer key={index} index={index} item={item} />;

--- a/inventory/src/js/itemIndex.js
+++ b/inventory/src/js/itemIndex.js
@@ -28,10 +28,13 @@ const ItemIndex = () => {
       <NavBar user={user} />
       <Stack
         direction='column'
-        justifyContent='center'
         alignItems='center'
         spacing={5}
-        sx={{ marginTop: 10 }}
+        marginTop={'100px'}
+        paddingTop={5}
+        sx={{
+          height: '100vh',
+        }}
       >
         {itemsToDisplay.map((item, index) => {
           return <ItemContainer key={index} index={index} item={item} />;

--- a/inventory/templates/items.html
+++ b/inventory/templates/items.html
@@ -5,6 +5,6 @@ Items{% endblock %} {% block content %}
   const userInfo = '{{userData|escapejs}}';
 </script>
 
-<div id="root" style="width: 100vw"></div>
+<div id="root" style="width: 100vw; height: 100vh;"></div>
 <script src="{% static 'js/itemIndex.js' %}"></script>
 {%endblock%}


### PR DESCRIPTION
Fixes #15 
* Fix navbar overlapping item containers
* Fix visual bug where ItemContainer elements are overflowing the container

Before:
<img width="483" alt="Screenshot 2023-06-11 at 12 20 31 PM" src="https://github.com/sjb-deck/deck/assets/55698556/e9964f30-1b9f-4ded-88bd-73706ac30225">

After:

https://github.com/sjb-deck/deck/assets/55698556/5985a69d-800d-49ae-bb35-64e75a59d61a


