### PR TITLE
Added cart button in FA homepage and badge that displays number of ca…

### DIFF
--- a/components/FloatingCart.js
+++ b/components/FloatingCart.js
@@ -1,0 +1,34 @@
+/**
+ * A React component that renders a floating cart that
+ * leads to the cart page and also has a badge that 
+ * indicates how many items are in the cart
+ * @returns FloatingCart
+ */
+
+import React from 'react';
+import { Button, Badge } from '@mui/material';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+import { getCartItems } from '../utils/cart-utils/getCartItems'
+import { URL_INV_CART } from '../globals';
+
+
+const FloatingCart = () => {
+    
+    const cartItems = getCartItems()
+  
+    return (
+        <Button 
+            onClick={() => window.location.href = URL_INV_CART} 
+            variant="contained" 
+            style={{ position: 'fixed', right: 20, bottom: 20, borderRadius: 28 }}>
+            <Badge 
+                color="secondary" 
+                badgeContent={(cartItems.length == 0) ? 0 : cartItems.length} 
+                showZero>
+                <ShoppingCartIcon  style={{ fontSize: 40 }}/>
+            </Badge>
+        </Button>
+    );
+}
+
+export default FloatingCart;

--- a/components/FloatingCart.js
+++ b/components/FloatingCart.js
@@ -1,34 +1,35 @@
 /**
  * A React component that renders a floating cart that
- * leads to the cart page and also has a badge that 
+ * leads to the cart page and also has a badge that
  * indicates how many items are in the cart
  * @returns FloatingCart
  */
 
-import React from 'react';
-import { Button, Badge } from '@mui/material';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import { getCartItems } from '../utils/cart-utils/getCartItems'
-import { URL_INV_CART } from '../globals';
+import { Button, Badge } from '@mui/material';
+import React from 'react';
 
+import { URL_INV_CART } from '../globals';
+import { getCartItems } from '../utils/cart-utils/getCartItems';
 
 const FloatingCart = () => {
-    
-    const cartItems = getCartItems()
-  
-    return (
-        <Button 
-            onClick={() => window.location.href = URL_INV_CART} 
-            variant="contained" 
-            style={{ position: 'fixed', right: 20, bottom: 20, borderRadius: 28 }}>
-            <Badge 
-                color="secondary" 
-                badgeContent={(cartItems.length == 0) ? 0 : cartItems.length} 
-                showZero>
-                <ShoppingCartIcon  style={{ fontSize: 40 }}/>
-            </Badge>
-        </Button>
-    );
-}
+  const cartItems = getCartItems();
+
+  return (
+    <Button
+      onClick={() => (window.location.href = URL_INV_CART)}
+      variant='contained'
+      style={{ position: 'fixed', right: 20, bottom: 20, borderRadius: 28 }}
+    >
+      <Badge
+        color='secondary'
+        badgeContent={cartItems.length == 0 ? 0 : cartItems.length}
+        showZero
+      >
+        <ShoppingCartIcon style={{ fontSize: 40 }} />
+      </Badge>
+    </Button>
+  );
+};
 
 export default FloatingCart;

--- a/pages/inventory/itemIndex.js
+++ b/pages/inventory/itemIndex.js
@@ -10,6 +10,7 @@ import NavBar from '../../components/NavBar/NavBar';
 import SearchBar from '../../components/SearchBar';
 import SearchFilter from '../../components/SearchFilter';
 import { SnackBarAlerts } from '../../components/SnackBarAlerts';
+import FloatingCart from '../../components/FloatingCart'
 import Theme from '../../components/Themes';
 import {
   INV_API_ITEMS_URL,
@@ -155,6 +156,8 @@ const ItemIndex = () => {
             </Skeleton>
           )}
         </Stack>
+
+        <FloatingCart />
 
         <Footer />
       </CartProvider>

--- a/pages/inventory/itemIndex.js
+++ b/pages/inventory/itemIndex.js
@@ -4,13 +4,13 @@ import Stack from '@mui/material/Stack';
 import React, { useEffect, useState } from 'react';
 
 import { CartProvider } from '../../components/CartContext';
+import FloatingCart from '../../components/FloatingCart';
 import Footer from '../../components/Footer';
 import ItemContainer from '../../components/ItemContainer/ItemContainer';
 import NavBar from '../../components/NavBar/NavBar';
 import SearchBar from '../../components/SearchBar';
 import SearchFilter from '../../components/SearchFilter';
 import { SnackBarAlerts } from '../../components/SnackBarAlerts';
-import FloatingCart from '../../components/FloatingCart'
 import Theme from '../../components/Themes';
 import {
   INV_API_ITEMS_URL,


### PR DESCRIPTION
Pull Request Details:

Description:
Added cart button in FA homepage and badge that displays the number of cart items
Closes #46 

Changes Made:
- Added a new component called "FloatingCart" that represents the cart button with a badge displaying the number of cart items
- However, the number of cart items does not change dynamically on the badge 
- Imported this component in "itemIndex.js" as "FloatingCart"
