### PR TITLE
Create API to create order for kits

### DIFF
--- a/inventory/items/globals.py
+++ b/inventory/items/globals.py
@@ -10,6 +10,7 @@ action_choices = (("Withdraw", "Withdraw"), ("Deposit", "Deposit"))
 
 action_reasons = (
     ("kit_restock", "Kit Restock"),
+    ("kit_retire", "Kit Retire"),
     ("loan", "Loan"),
     ("unserviceable", "Unserviceable"),
     ("others", "Others"),

--- a/inventory/items/views_utils.py
+++ b/inventory/items/views_utils.py
@@ -1,3 +1,8 @@
+from inventory.items.serializers import OrderSerializer
+
+import json
+
+
 def manage_items_change(order):
     try:
         action = order.action
@@ -9,4 +14,24 @@ def manage_items_change(order):
                 item_expiry.deposit(item.ordered_quantity)
     except Exception as e:
         print("Error when updating quantity")
+        raise e
+
+
+# Returns a promise that creates an order, updates the quantity of the items,
+# updates other_info with the kit data and returns the order id
+def create_order(data, request):
+    try:
+        serializer = OrderSerializer(data=data, context={"request": request})
+        if serializer.is_valid(raise_exception=True):
+
+            def promise(kit):
+                order = serializer.save()
+                manage_items_change(order)
+                order.other_info = json.dumps({"kit_id": kit.id, "kit_name": kit.name})
+                order.save()
+                return order.id
+
+            return promise
+    except Exception as e:
+        print("Error when creating order")
         raise e

--- a/inventory/items/views_utils.py
+++ b/inventory/items/views_utils.py
@@ -17,21 +17,13 @@ def manage_items_change(order):
         raise e
 
 
-# Returns a promise that creates an order, updates the quantity of the items,
-# updates other_info with the kit data and returns the order id
 def create_order(data, request):
     try:
         serializer = OrderSerializer(data=data, context={"request": request})
         if serializer.is_valid(raise_exception=True):
-
-            def promise(kit):
-                order = serializer.save()
-                manage_items_change(order)
-                order.other_info = json.dumps({"kit_id": kit.id, "kit_name": kit.name})
-                order.save()
-                return order.id
-
-            return promise
+            order = serializer.save()
+            manage_items_change(order)
+            return order
     except Exception as e:
         print("Error when creating order")
         raise e

--- a/inventory/kits/views.py
+++ b/inventory/kits/views.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from django.db import transaction
 
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -60,7 +61,7 @@ def add_kit(request):
         if Kit.objects.filter(name=name).exists():
             return Response({"error": "Kit with this name already exists!"}, status=status.HTTP_400_BAD_REQUEST)
 
-        blueprint = Blueprint.objects.get(id=blueprint_id, status="ACTIVE")
+        blueprint = Blueprint.objects.get(id=blueprint_id)
         compressed_content = compress_content(content)
 
         if not content_matches(compressed_content, blueprint.complete_content):
@@ -69,25 +70,23 @@ def add_kit(request):
         if add_more_than_expected(compressed_content, blueprint.complete_content):
             return Response({"error": "Added content is more than expected."}, status=status.HTTP_400_BAD_REQUEST)
 
-        res = attempt_items_withdrawal(content)
-        item_insufficient = res[1]
-        if not res[0]:
-            return Response({"error": f"Insufficient stock for {item_insufficient}."}, status=status.HTTP_400_BAD_REQUEST)
+        with transaction.atomic():
+            new_kit = Kit.objects.create(
+                name=name,
+                blueprint=blueprint,
+                status="READY",
+                content=content,
+            )
+            
+            order_id = transact_items(content, request, new_kit, isWithdraw=True)
 
-        new_kit = Kit.objects.create(
-            name=name,
-            blueprint=blueprint,
-            status="READY",
-            content=content,
-        )
-
-        History.objects.create(
-            kit=new_kit,
-            type="CREATION",
-            date=datetime.date.today(),
-            person=username,
-            snapshot=content
-        )
+            History.objects.create(
+                kit=new_kit,
+                type="CREATION",
+                date=datetime.date.today(),
+                person=username,
+                snapshot=content
+            )
 
         return Response({"message": "Kit added successfully!"},
                         status=status.HTTP_201_CREATED)

--- a/inventory/kits/views_utils.py
+++ b/inventory/kits/views_utils.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from .models import Kit, Blueprint, LoanHistory
 from ..items.models import *
+from ..items.views_utils import create_order
 
 
 def compress_content(content):
@@ -68,6 +69,20 @@ def attempt_items_deposit(content):
         item["quantity"] = 0
 
     return True
+
+
+# Builds payload to call create_order which returns a promise
+def transact_items(isWithdraw, content, request):
+    order_items = [
+        {"item_expiry_id": item["item_expiry_id"], "ordered_quantity": item["quantity"]}
+        for item in content
+    ]
+    payload = {
+        "action": "Withdraw" if isWithdraw else "Deposit",
+        "reason": "kit_restock" if isWithdraw else "kit_retire",
+        "order_items": order_items,
+    }
+    return create_order(payload, request)
 
 
 def kit_is_complete(kit_id):

--- a/inventory/kits/views_utils.py
+++ b/inventory/kits/views_utils.py
@@ -71,8 +71,8 @@ def attempt_items_deposit(content):
     return True
 
 
-# Builds payload to call create_order which returns a promise
-def transact_items(isWithdraw, content, request):
+# Builds payload to call create_order which returns a order_id
+def transact_items(content, request, kit, isWithdraw):
     order_items = [
         {"item_expiry_id": item["item_expiry_id"], "ordered_quantity": item["quantity"]}
         for item in content
@@ -82,7 +82,12 @@ def transact_items(isWithdraw, content, request):
         "reason": "kit_restock" if isWithdraw else "kit_retire",
         "order_items": order_items,
     }
-    return create_order(payload, request)
+    order = create_order(payload, request)
+
+    # Update other_info with kit data
+    order.other_info = json.dumps({"kit_id": kit.id, "kit_name": kit.name})
+    order.save()
+    return order.id
 
 
 def kit_is_complete(kit_id):


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Usage:
* Call `transact_items` which returns order_id

Note:
* No need for validation as validation will be done in `OrderSerializer` 
* Have to wrap any changes to DB in `with transaction.atomic():`

<!-- Fixes # (issue) -->

## Type of change

- [ ] Bug fix <!--(non-breaking change which fixes an issue)-->
- [ ] New feature <!--(non-breaking change which adds functionality)-->
- [ ] Breaking change <!--(fix or feature that would cause existing functionality to not work as expected)-->

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Add screenshots or screen records to show the changes and tests-->
