### PR TITLE
Fix kits api

### DIFF
--- a/deck/settings.py
+++ b/deck/settings.py
@@ -92,24 +92,16 @@ REST_FRAMEWORK = {
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
 
-if sys.argv[1] == "test":
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": ":memory:",
-        }
-    }
-else:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.mysql",
-            "NAME": "deck_staging",
-            "HOST": config("DB_HOST"),
-            "PORT": "3306",
-            "USER": config("DB_USER"),
-            "PASSWORD": config("DB_PW"),
-        },
-    }
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "deck_staging",
+        "HOST": config("DB_HOST"),
+        "PORT": "3306",
+        "USER": config("DB_USER"),
+        "PASSWORD": config("DB_PW"),
+    },
+}
 
 # uncomment this to use local db
 # DATABASES = {

--- a/deck/settings.py
+++ b/deck/settings.py
@@ -92,16 +92,24 @@ REST_FRAMEWORK = {
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.mysql",
-        "NAME": "deck_staging",
-        "HOST": config("DB_HOST"),
-        "PORT": "3306",
-        "USER": config("DB_USER"),
-        "PASSWORD": config("DB_PW"),
-    },
-}
+if sys.argv[1] == "test":
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    }
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.mysql",
+            "NAME": "deck_staging",
+            "HOST": config("DB_HOST"),
+            "PORT": "3306",
+            "USER": config("DB_USER"),
+            "PASSWORD": config("DB_PW"),
+        },
+    }
 
 # uncomment this to use local db
 # DATABASES = {

--- a/inventory/kits/__tests__/api/test_api_add_blueprint.py
+++ b/inventory/kits/__tests__/api/test_api_add_blueprint.py
@@ -22,21 +22,14 @@ class TestApiAddBlueprintViews(TestCase):
         self.url = reverse("add_blueprint")
         self.clear_relevant_models()
         self.create_items()
-        self.item_expiry1_id = self.itemExpiry1.id
-        self.item_expiry2_id = self.itemExpiry2.id
-        self.item_no_expiry_id = self.itemExpiry_no_expiry.id
-        self.request = {
-            "name": "Test Blueprint",
-            "content": [
-                {"item_expiry_id": self.item_expiry1_id, "quantity": 5},
-                {"item_expiry_id": self.item_expiry2_id, "quantity": 5},
-                {"item_expiry_id": self.item_no_expiry_id, "quantity": 5},
-            ],
-        }
-        self.compressed_blueprint_content = [
+        self.content = [
             {"item_id": self.item.id, "quantity": 10},
             {"item_id": self.item_no_expiry.id, "quantity": 5},
         ]
+        self.request = {
+            "name": "Test Blueprint",
+            "content": self.content,
+        }
 
     def create_items(self):
         self.item = Item.objects.create(
@@ -80,7 +73,7 @@ class TestApiAddBlueprintViews(TestCase):
         self.assertEqual(blueprint.name, "Test Blueprint")
 
         # check that blueprint content is created with correct compression
-        self.assertEqual(blueprint.complete_content, self.compressed_blueprint_content)
+        self.assertEqual(blueprint.complete_content, self.content)
 
     def test_create_new_blueprint_with_same_name(self):
         response = self.client.post(self.url, self.request, format="json")
@@ -113,13 +106,24 @@ class TestApiAddBlueprintViews(TestCase):
         self.assertEqual(response.data["message"], "Required parameters are missing!")
         self.request["content"] = content
 
-    def test_create_new_blueprint_with_invalid_item_expiry_id(self):
-        self.request["content"][0]["item_expiry_id"] = 0
+    def test_create_new_blueprint_with_invalid_item_id(self):
+        self.request["content"][0]["item_id"] = 999
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            response.data["message"], "ItemExpiry matching query does not exist."
+            response.data["message"], "Item matching query does not exist."
         )
+        self.request["content"][0]["item_id"] = self.item.id
+
+    def test_create_new_blueprint_with_invalid_quantity(self):
+        quantity = self.request["content"][0]["quantity"]
+        self.request["content"][0]["quantity"] = -1
+        response = self.client.post(self.url, self.request, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["message"], "Quantity cannot be negative."
+        )
+        self.request["content"][0]["quantity"] = quantity
 
     def tearDown(self):
         self.clear_relevant_models()

--- a/inventory/kits/__tests__/api/test_api_add_blueprint.py
+++ b/inventory/kits/__tests__/api/test_api_add_blueprint.py
@@ -120,9 +120,7 @@ class TestApiAddBlueprintViews(TestCase):
         self.request["content"][0]["quantity"] = -1
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.data["message"], "Quantity cannot be negative."
-        )
+        self.assertEqual(response.data["message"], "Quantity cannot be negative.")
         self.request["content"][0]["quantity"] = quantity
 
     def tearDown(self):

--- a/inventory/kits/__tests__/api/test_api_kit_history.py
+++ b/inventory/kits/__tests__/api/test_api_kit_history.py
@@ -54,14 +54,14 @@ class TestApiKitHistoryViews(TestCase):
 
         # Submit a kit order
         request = {
-            "kit_id": self.kit_id,
+            "kit_ids": [self.kit_id],
             "force": True,
             "loanee_name": "test loanee",
             "due_date": "2050-01-01",
         }
         response = self.client.post(reverse("submit_kit_order"), request, format="json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["message"], "Kit loaned successfully!")
+        self.assertEqual(response.data["message"], "Kit(s) loaned successfully!")
 
         # Return the kit
         self.return_content = [

--- a/inventory/kits/__tests__/api/test_api_return_kit_order.py
+++ b/inventory/kits/__tests__/api/test_api_return_kit_order.py
@@ -50,14 +50,14 @@ class TestApiReturnKitOrderViews(TestCase):
 
     def loan_kit(self):
         request = {
-            "kit_id": self.kit_id,
+            "kit_ids": [self.kit_id],
             "force": False,
             "loanee_name": "test loanee",
             "due_date": "2050-01-01",
         }
         response = self.client.post(reverse("submit_kit_order"), request, format="json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["message"], "Kit loaned successfully!")
+        self.assertEqual(response.data["message"], "Kit(s) loaned successfully!")
 
     def create_kit(self):
         self.kit = Kit.objects.create(
@@ -184,7 +184,7 @@ class TestApiReturnKitOrderViews(TestCase):
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data["message"], "Required parameters are missing!")
-        self.request["kit_id"] = self.kit_id
+        self.request["kit_ids"] = [self.kit_id]
 
         content = self.request.pop("content")
         response = self.client.post(self.url, self.request, format="json")

--- a/inventory/kits/__tests__/api/test_api_revert_kit.py
+++ b/inventory/kits/__tests__/api/test_api_revert_kit.py
@@ -48,7 +48,9 @@ class TestApiRevertReturnOrderViews(TestCase):
             reverse("retire_kit", args=[self.kit_id[3]]), None, format="json"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["message"], "Kit retired and contents deposited successfully!")
+        self.assertEqual(
+            response.data["message"], "Kit retired and contents deposited successfully!"
+        )
 
     def restock_kit(self):
         request = {
@@ -83,19 +85,19 @@ class TestApiRevertReturnOrderViews(TestCase):
 
     def loan_kits(self):
         request = {
-            "kit_id": 999,
+            "kit_ids": [999],
             "force": False,
             "loanee_name": "test loanee",
             "due_date": "2050-01-01",
         }
 
         for i in range(3):
-            request["kit_id"] = self.kit_id[i]
+            request["kit_ids"] = [self.kit_id[i]]
             response = self.client.post(
                 reverse("submit_kit_order"), request, format="json"
             )
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.data["message"], "Kit loaned successfully!")
+            self.assertEqual(response.data["message"], "Kit(s) loaned successfully!")
 
     def create_kits(self):
         self.kit_id = array("i", [0, 0, 0, 0])
@@ -219,7 +221,9 @@ class TestApiRevertReturnOrderViews(TestCase):
             reverse("revert_kit", args=[history.id]), format="json"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["message"], "Kit retirement reverted successfully!")
+        self.assertEqual(
+            response.data["message"], "Kit retirement reverted successfully!"
+        )
 
         kit = Kit.objects.get(id=self.kit_id[3])
         self.assertEqual(kit.status, "READY")

--- a/inventory/kits/__tests__/api/test_api_submit_kit_order.py
+++ b/inventory/kits/__tests__/api/test_api_submit_kit_order.py
@@ -126,7 +126,9 @@ class TestApiSubmitKitOrderViews(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.data["message"],
-            "Kit with id=" + str(self.incomplete_kit_id) + " is not complete and cannot be loaned.",
+            "Kit with id="
+            + str(self.incomplete_kit_id)
+            + " is not complete and cannot be loaned.",
         )
 
         # check that kits are not loaned
@@ -155,7 +157,9 @@ class TestApiSubmitKitOrderViews(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.data["message"],
-            "Kit with id=" + str(self.incomplete_kit_id) + " is not complete and cannot be loaned.",
+            "Kit with id="
+            + str(self.incomplete_kit_id)
+            + " is not complete and cannot be loaned.",
         )
 
         self.request["force"] = True

--- a/inventory/kits/__tests__/api/test_api_submit_kit_order.py
+++ b/inventory/kits/__tests__/api/test_api_submit_kit_order.py
@@ -45,7 +45,7 @@ class TestApiSubmitKitOrderViews(TestCase):
         self.incomplete_kit_id = self.incomplete_kit.id
         self.url = reverse("submit_kit_order")
         self.request = {
-            "kit_id": self.kit_id,
+            "kit_ids": [self.kit_id],
             "force": False,
             "loanee_name": "test loanee",
             "due_date": "2050-01-01",
@@ -109,7 +109,7 @@ class TestApiSubmitKitOrderViews(TestCase):
     def test_order_kit(self):
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["message"], "Kit loaned successfully!")
+        self.assertEqual(response.data["message"], "Kit(s) loaned successfully!")
 
         # check that kit is loaned
         kit = Kit.objects.get(id=self.kit_id)
@@ -119,10 +119,30 @@ class TestApiSubmitKitOrderViews(TestCase):
         history = History.objects.get(kit=kit)
         self.assertEqual(history.type, "LOAN")
 
+    def test_order_kit_atomicity(self):
+        kit_ids = self.request["kit_ids"]
+        self.request["kit_ids"] = [self.kit_id, self.incomplete_kit_id]
+        response = self.client.post(self.url, self.request, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["message"],
+            "Kit with id=2 is not complete and cannot be loaned.",
+        )
+
+        # check that kits are not loaned
+        kit = Kit.objects.get(id=self.kit_id)
+        self.assertEqual(kit.status, "READY")
+        kit = Kit.objects.get(id=self.incomplete_kit_id)
+        self.assertEqual(kit.status, "READY")
+
+        # check that history is not created
+        self.assertFalse(History.objects.filter(kit_id=self.kit_id).exists())
+        self.assertFalse(History.objects.filter(kit_id=self.incomplete_kit_id).exists())
+
     def test_order_kit_that_is_already_loaned(self):
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["message"], "Kit loaned successfully!")
+        self.assertEqual(response.data["message"], "Kit(s) loaned successfully!")
 
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 400)
@@ -130,18 +150,18 @@ class TestApiSubmitKitOrderViews(TestCase):
 
     def test_order_kit_force(self):
         # check that kit is incomplete and cannot be loaned normally
-        self.request["kit_id"] = self.incomplete_kit_id
+        self.request["kit_ids"] = [self.incomplete_kit_id]
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.data["message"],
-            "Kit is not complete and normal loan if not possible.",
+            "Kit with id=2 is not complete and cannot be loaned.",
         )
 
         self.request["force"] = True
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["message"], "Kit loaned successfully!")
+        self.assertEqual(response.data["message"], "Kit(s) loaned successfully!")
 
         # check that kit is loaned
         kit = Kit.objects.get(id=self.incomplete_kit_id)
@@ -152,14 +172,14 @@ class TestApiSubmitKitOrderViews(TestCase):
         self.assertEqual(history.type, "LOAN")
 
         self.request["force"] = False
-        self.request["kit_id"] = self.kit_id
+        self.request["kit_ids"] = [self.kit_id]
 
     def test_order_kit_invalid_kit_id(self):
-        self.request["kit_id"] = 999
+        self.request["kit_ids"] = [999]
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data["message"], "Kit matching query does not exist.")
-        self.request["kit_id"] = self.kit_id
+        self.request["kit_ids"] = [self.kit_id]
 
     def test_order_kit_invalid_loanee_name(self):
         loanee_name = self.request["loanee_name"]
@@ -184,16 +204,18 @@ class TestApiSubmitKitOrderViews(TestCase):
         self.request["due_date"] = "XXX"
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data["message"], "Invalid date format.")
+        self.assertEqual(
+            response.data["message"], "time data 'XXX' does not match format '%Y-%m-%d'"
+        )
 
         self.request["due_date"] = due_date
 
     def test_order_kit_missing_fields(self):
-        id = self.request.pop("kit_id")
+        id = self.request.pop("kit_ids")
         response = self.client.post(self.url, self.request, format="json")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data["message"], "Required parameters are missing!")
-        self.request["kit_id"] = id
+        self.request["kit_ids"] = id
 
         loanee_name = self.request.pop("loanee_name")
         response = self.client.post(self.url, self.request, format="json")

--- a/inventory/kits/__tests__/api/test_api_submit_kit_order.py
+++ b/inventory/kits/__tests__/api/test_api_submit_kit_order.py
@@ -126,7 +126,7 @@ class TestApiSubmitKitOrderViews(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.data["message"],
-            "Kit with id=2 is not complete and cannot be loaned.",
+            "Kit with id=" + str(self.incomplete_kit_id) + " is not complete and cannot be loaned.",
         )
 
         # check that kits are not loaned
@@ -155,7 +155,7 @@ class TestApiSubmitKitOrderViews(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.data["message"],
-            "Kit with id=2 is not complete and cannot be loaned.",
+            "Kit with id=" + str(self.incomplete_kit_id) + " is not complete and cannot be loaned.",
         )
 
         self.request["force"] = True

--- a/inventory/kits/views_utils.py
+++ b/inventory/kits/views_utils.py
@@ -169,7 +169,11 @@ def get_restock_options(blueprint_id, given_content):
             main_item = Item.objects.get(id=current_item["item_id"])
             missing_quantity = blueprint_item["quantity"] - current_item["quantity"]
 
-            options = main_item.expiry_dates.all().order_by("expiry_date")
+            options = (
+                main_item.expiry_dates.all()
+                .filter(archived=False)
+                .order_by("expiry_date")
+            )
             item_options = []
 
             for option in options:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Closes #171 

Fixes the following:
* Allow for reverting retirement kit histories
* Update `submit_kit_order` to take in an array of `kit_ids`
* Filter out archived expiries in `get_restock_options`
* `add_blueprint` should accept `item_id` instead of `item_expiry_id`.

***Important Note***
- `submit_kit_order` now accepts `kit_ids` instead of `kit_id` in the request payload to signify that it is now an array, regardless of whether there is one or more than one ids.
- `submit_kit_order` is atomic, either all kits indicated in the array are loaned successfully or none at all. If an error occur when ordering (loaning) out a kit, no kits shall be loaned and the id is indicated in the returned message.


<!-- Fixes # (issue) -->

## Type of change

- [X] Bug fix <!--(non-breaking change which fixes an issue)-->

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Add screenshots or screen records to show the changes and tests-->

All backend tests are updated to accommodate the changes, with additional tests added for:
* reversion of kit retirement
* atomicity of submitting kit order
